### PR TITLE
Place some default blocks on site install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         "drupal/console": "~1.0",
         "drupal/devel": "^2.1",
         "drush/drush": "~9",
-        "localgovdrupal/localgov_core": "dev-feature/14-move-block-config",
+        "localgovdrupal/localgov_core": "dev-master",
         "localgovdrupal/localgov_services": "dev-master",
         "localgovdrupal/localgov_paragraphs": "dev-master",
-        "localgovdrupal/localgov_theme": "dev-feature/14-header-and-footer"
+        "localgovdrupal/localgov_theme": "dev-master"
     },
     "require-dev": {
         "drupal/core-dev": "^8.8"

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         "drupal/console": "~1.0",
         "drupal/devel": "^2.1",
         "drush/drush": "~9",
-        "localgovdrupal/localgov_core": "dev-master",
+        "localgovdrupal/localgov_core": "dev-feature/14-move-block-config",
         "localgovdrupal/localgov_services": "dev-master",
         "localgovdrupal/localgov_paragraphs": "dev-master",
-        "localgovdrupal/localgov_theme": "dev-master"
+        "localgovdrupal/localgov_theme": "dev-feature/14-header-and-footer"
     },
     "require-dev": {
         "drupal/core-dev": "^8.8"

--- a/config/install/block.block.localgov_breadcrumbs.yml
+++ b/config/install/block.block.localgov_breadcrumbs.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - localgov_theme
+id: localgov_breadcrumbs
+theme: localgov_theme
+region: breadcrumb
+weight: 0
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/config/install/block.block.localgov_mainnavigation.yml
+++ b/config/install/block.block.localgov_mainnavigation.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.main
+  module:
+    - system
+  theme:
+    - localgov_theme
+id: localgov_mainnavigation
+theme: localgov_theme
+region: primary_menu
+weight: -1
+provider: null
+plugin: 'system_menu_block:main'
+settings:
+  id: 'system_menu_block:main'
+  label: 'Main navigation'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility: {  }

--- a/config/install/block.block.localgov_mainpagecontent.yml
+++ b/config/install/block.block.localgov_mainpagecontent.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - localgov_theme
+id: localgov_mainpagecontent
+theme: localgov_theme
+region: content
+weight: 0
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/config/install/block.block.localgov_messages.yml
+++ b/config/install/block.block.localgov_messages.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - localgov_theme
+id: localgov_messages
+theme: localgov_theme
+region: messages
+weight: 0
+provider: null
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: Messages
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/config/install/block.block.localgov_nodeheaderblock.yml
+++ b/config/install/block.block.localgov_nodeheaderblock.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_core
+  theme:
+    - localgov_theme
+id: localgov_nodeheaderblock
+theme: localgov_theme
+region: content_top
+weight: -1
+provider: null
+plugin: localgov_node_header_block
+settings:
+  id: localgov_node_header_block
+  label: 'Node header block'
+  provider: localgov_core
+  label_display: '0'
+visibility: {  }

--- a/config/install/block.block.localgov_poweredbylocalgovdrupal.yml
+++ b/config/install/block.block.localgov_poweredbylocalgovdrupal.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_core
+  theme:
+    - localgov_theme
+id: localgov_poweredbylocalgovdrupal
+theme: localgov_theme
+region: footer_second
+weight: 0
+provider: null
+plugin: localgov_powered_by_block
+settings:
+  id: localgov_powered_by_block
+  label: 'Powered by LocalGovDrupal'
+  provider: localgov_core
+  label_display: '0'
+visibility: {  }

--- a/config/install/block.block.localgov_sitebranding.yml
+++ b/config/install/block.block.localgov_sitebranding.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - localgov_theme
+id: localgov_sitebranding
+theme: localgov_theme
+region: header
+weight: 0
+provider: null
+plugin: system_branding_block
+settings:
+  id: system_branding_block
+  label: 'Site branding'
+  provider: system
+  label_display: '0'
+  use_site_logo: true
+  use_site_name: true
+  use_site_slogan: false
+visibility: {  }

--- a/config/install/block.block.localgov_tabs.yml
+++ b/config/install/block.block.localgov_tabs.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  theme:
+    - localgov_theme
+id: localgov_tabs
+theme: localgov_theme
+region: content_top
+weight: 0
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: Tabs
+  provider: core
+  label_display: '0'
+  primary: true
+  secondary: true
+visibility: {  }


### PR DESCRIPTION
This places a number of system and related blocks on a site install.

There are a number of related merge requests:

- https://github.com/localgovdrupal/localgov_theme/pull/22
- https://github.com/localgovdrupal/localgov_core/pull/10

To test this you will need to checkout the https://github.com/localgovdrupal/localgov_project/tree/feature/60-default-blocks branch in your project repo and run `composer update --no-cache`

If a composer update doesn't pull down the related branches try the nuclear option:

```
rm -fr web/profiles/
rm -fr web/modules/
rm -fr web/themes/
composer cc
composer update --no-cache
```

Once we're happy with this merge request please don't merge it. I need to change the `composer.json` file before it can be merged.