### PR TITLE
Add localgov guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ If you want to be sure you are getting the latest commits when developing, clear
 
 ```bash
 rm -rf web/profiles/contrib/ web/modules/contrib/; 
-composer clear-cache; composer update --with-dependencies --no-cache; 
+composer clear-cache; composer update --with-dependencies --no-cache;
+lando start;
 lando drush si localgov -y;
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ update with the `--no-cache` flag.
 composer update --no-cache
 ```
 
+If you want to be sure you are getting the latest commits when developing, clearing composer cache, deleting the folders and re-running composer update seems to be a solid approach:
+
+```bash
+rm -rf web/profiles/contrib/ web/modules/contrib/; 
+composer clear-cache; composer update --with-dependencies --no-cache; 
+lando drush si localgov -y;
+```
+
 ## Contributing
 
 The development and contribution processes and standards proposed in the

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "drupal/devel": "^2.1",
         "drush/drush": "~9",
         "localgovdrupal/localgov_core": "dev-master",
-        "localgovdrupal/localgov_services": "dev-feature/31-service-paths-other",
+        "localgovdrupal/localgov_services": "dev-master",
         "localgovdrupal/localgov_paragraphs": "dev-master",
         "localgovdrupal/localgov_theme": "dev-master",
         "localgovdrupal/localgov_guides": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "drupal/devel": "^2.1",
         "drush/drush": "~9",
         "localgovdrupal/localgov_core": "dev-master",
-        "localgovdrupal/localgov_services": "dev-master",
+        "localgovdrupal/localgov_services": "dev-feature/31-service-paths-other",
         "localgovdrupal/localgov_paragraphs": "dev-master",
         "localgovdrupal/localgov_theme": "dev-master",
         "localgovdrupal/localgov_guides": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "localgovdrupal/localgov_core": "dev-master",
         "localgovdrupal/localgov_services": "dev-master",
         "localgovdrupal/localgov_paragraphs": "dev-master",
-        "localgovdrupal/localgov_theme": "dev-master"
+        "localgovdrupal/localgov_theme": "dev-master",
+        "localgovdrupal/localgov_guides": "dev-master"
     },
     "require-dev": {
         "drupal/core-dev": "^8.8"


### PR DESCRIPTION
Add LocalGov Guides to distro.

Review:
  *   localgovdrupal/localgov_guides#1
  *   localgovdrupal/localgov_guides#2
  *   localgovdrupal/localgov_guides#3
  *   localgovdrupal/localgov_guides#5

Includes 378d0fb to for PR localgovdrupal/localgov_services#49 which related and needed for tests. Should be reverted before merge.