### PR TITLE
Feature/96 simple home page

### DIFF
--- a/config/install/block.block.localgov_home_welcome_block.yml
+++ b/config/install/block.block.localgov_home_welcome_block.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
 dependencies:
-  module:
-    - localgov_core
   theme:
     - localgov_theme
 id: localgov_home_welcome_block
@@ -14,7 +12,7 @@ plugin: localgov_home_welcome_block
 settings:
   id: localgov_home_welcome_block
   label: 'Home welcome block'
-  provider: localgov_core
+  provider: null
   label_display: '0'
 visibility:
   request_path:

--- a/config/install/block.block.localgov_home_welcome_block.yml
+++ b/config/install/block.block.localgov_home_welcome_block.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_core
+  theme:
+    - localgov_theme
+id: localgov_home_welcome_block
+theme: localgov_theme
+region: content_top
+weight: 0
+provider: null
+plugin: localgov_home_welcome_block
+settings:
+  id: localgov_home_welcome_block
+  label: 'Home welcome block'
+  provider: localgov_core
+  label_display: '0'
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: false
+    context_mapping: {  }

--- a/config/install/block.block.localgov_services_block.yml
+++ b/config/install/block.block.localgov_services_block.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.services
+  module:
+    - system
+    - views
+    - localgov_core
+  theme:
+    - localgov_theme
+id: views_block__services_block_service_list
+theme: localgov_theme
+region: content_top
+weight: -4
+provider: null
+plugin: 'views_block:services-block_service_list'
+settings:
+  id: 'views_block:services-block_service_list'
+  label: 'Services list block'
+  provider: views
+  label_display: '0'
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: false
+    context_mapping: {  }

--- a/config/install/block.block.views_block__services_block_service_list.yml
+++ b/config/install/block.block.views_block__services_block_service_list.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__services_block_service_list
 theme: localgov_theme
 region: content_top
-weight: -4
+weight: 5
 provider: null
 plugin: 'views_block:services-block_service_list'
 settings:

--- a/src/Plugin/Block/HomeWelcomeBlock.php
+++ b/src/Plugin/Block/HomeWelcomeBlock.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\localgov\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a home page welcome block.
+ *
+ * @Block(
+ *   id = "localgov_home_welcome_block",
+ *   admin_label = @Translation("Home welcome block")
+ * )
+ */
+class HomeWelcomeBlock extends BlockBase implements BlockPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['label_display' => FALSE];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+
+    $config = $this->getConfiguration();
+
+    if (!empty($config['localgov_home_welcome_message'])) {
+      $message = $config['localgov_home_welcome_message']['value'];
+    }
+    else {
+      $message = $this->t('<h2>You have just installed a LocalGov Drupal site</h2>');
+    }
+
+    return [
+      '#markup' => $message,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+
+    $form = parent::blockForm($form, $form_state);
+    $config = $this->getConfiguration();
+
+    $form['localgov_home_welcome_message'] = [
+      '#type' => 'text_format',
+      '#format' => 'wysiwyg',
+      '#title' => $this->t('Welcome message'),
+      '#description' => $this->t('Site installation welcome message'),
+      '#default_value' => isset($config['localgov_home_welcome_message']) ? $config['localgov_home_welcome_message']['value'] : '',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+
+    $this->configuration['localgov_home_welcome_message'] = $form_state->getValue('localgov_home_welcome_message');
+  }
+
+}


### PR DESCRIPTION
This PR adds two blocks to the homepage on installation:

- Welcome message (dependent on: [/localgovdrupal/localgov_core/pull/27](/localgovdrupal/localgov_core/pull/27))
- Services list (dependent on: [/localgovdrupal/localgov_services/pull/65](/localgovdrupal/localgov_services/pull/65))

Closes #96 