### PR TITLE
Upgrade to Drush 10.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/console": "~1.0",
         "drupal/devel": "^2.1",
         "drupal/simple_sitemap": "^3.7",
-        "drush/drush": "~10",
+        "drush/drush": ">=10",
         "localgovdrupal/localgov_alert_banner": "dev-master",
         "localgovdrupal/localgov_core": "dev-master",
         "localgovdrupal/localgov_campaigns": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/console": "~1.0",
         "drupal/devel": "^2.1",
         "drupal/simple_sitemap": "^3.7",
-        "drush/drush": "~9",
+        "drush/drush": "~10",
         "localgovdrupal/localgov_alert_banner": "dev-master",
         "localgovdrupal/localgov_core": "dev-master",
         "localgovdrupal/localgov_campaigns": "dev-master",


### PR DESCRIPTION
Recommended version for Drupal 8.4+ https://www.drush.org/install/#drupal-compatibility So will also be needed for 9. 
Supports the new configuration ExportStorage, which means new config management tools will use it, and so will https://github.com/localgovdrupal/localgov_directories/blob/master/src/EventSubscriber/DirectoriesConfigSubscriber.php

You will need to `drush cr` and `drush cc drush`.