### PR TITLE
Enable localgov_core:localgov_roles by default on localgov profile install.

### DIFF
--- a/localgov.info.yml
+++ b/localgov.info.yml
@@ -41,6 +41,7 @@ install:
   # LocalGov Drupal
   - localgov_core:localgov_core
   - localgov_core:localgov_media
+  - localgov_core:localgov_roles
   - localgov_menu_link_group:localgov_menu_link_group
   - localgov_page_components:localgov_page_components
   - localgov_paragraphs:localgov_paragraphs

--- a/tests/src/Functional/LocalGovProfileTest.php
+++ b/tests/src/Functional/LocalGovProfileTest.php
@@ -17,11 +17,11 @@ class LocalGovProfileTest extends BrowserTestBase {
   protected $profile = 'localgov';
 
   /**
-   * Test core modules enabled and uninstallable.
+   * Test localgov profile was installed and basic site functions.
    */
   public function testLocalGovDrupalProfile() {
 
-    // Test core modules enabled and uninstallable.
+    // Test localgov_core module is enabled and is not uninstallable.
     $this->assertTrue($this->container->get('module_handler')->moduleExists('localgov_core'));
     try {
       $this->container->get('module_installer')->uninstall(['localgov_core']);
@@ -30,6 +30,9 @@ class LocalGovProfileTest extends BrowserTestBase {
     catch (ModuleUninstallValidatorException $e) {
       $this->assertContains('module is required', $e->getMessage());
     }
+
+    // Test localgov_core:localgov_roles submodule is enabled.
+    $this->assertTrue($this->container->get('module_handler')->moduleExists('localgov_roles'));
 
     // Test front page loads after site install.
     $this->drupalGet('<front>');


### PR DESCRIPTION
Added localgov_roles submodule to install section of localgov.info.yml.

Added test to LocalGovProfileTest.php checking the submodule has been enabled and added, improved and synced comments with code.