### PR TITLE
Restarting pr:  Feature/150 enable localgov roles submodule on install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  instance-1:
+  test:
     name: 'Execute run-tests.sh'
     runs-on: ubuntu-latest
 
@@ -43,8 +43,8 @@ jobs:
           composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
           composer global config github-oauth.github.com ${{ github.token }}
 
-      - name: Grab test target for hardcoded package name 'localgov'
-        run: composer --working-dir=html require localgovdrupal/localgov:"dev-${GIT_BRANCH} as 1.0.x-dev"
+      - name: Grab test target from this repo
+        run: composer --working-dir=html require localgovdrupal/${{ github.event.repository.name }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
 
       - name: Start Docker environment
         run: docker-compose up -d

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,14 @@
-name: Test LocalGov Drupal
+name: Execute Drupal's run-tests.sh for this branch
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-  test:
-
+  instance-1:
+    name: 'Execute run-tests.sh'
     runs-on: ubuntu-latest
 
     steps:
@@ -16,8 +16,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
- 
-      - name: Clone drupal_container
+
+      - name: Clone drupal-container
         uses: actions/checkout@v2
         with:
           repository: localgovdrupal/drupal-container
@@ -26,20 +26,25 @@ jobs:
       - name: Create LocalGov Drupal project
         run: composer create-project --stability dev localgovdrupal/localgov-project html
 
-      - name: Setup package source for the test target
-        run: |
-          composer --working-dir=html config repositories.1 vcs git@github.com:${{ github.repository }}.git
-          composer global config github-oauth.github.com ${{ github.token }}
-      - name: Extract Git branch name outside of a pull request
+      - name: Save git branch and git repo names to env if not a pull request
         if: github.event_name != 'pull_request'
-        run: echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: |
+          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
 
-      - name: Extract Git branch name from a pull request
+      - name: Save git branch and git repo names to env if is a pull request
         if: github.event_name == 'pull_request'
-        run: echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        run: |
+          echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
 
-      - name: Grab test target
-        run: composer --working-dir=html require ${{ github.repository }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
+      - name: Setup package source and authentication for the test target
+        run: |
+          composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
+          composer global config github-oauth.github.com ${{ github.token }}
+
+      - name: Grab test target for hardcoded package name 'localgov'
+        run: composer --working-dir=html require localgovdrupal/localgov:"dev-${GIT_BRANCH} as 1.0.x-dev"
 
       - name: Start Docker environment
         run: docker-compose up -d

--- a/localgov.info.yml
+++ b/localgov.info.yml
@@ -41,6 +41,7 @@ install:
   # LocalGov Drupal
   - localgov_core:localgov_core
   - localgov_core:localgov_media
+  - localgov_core:localgov_roles
   - localgov_menu_link_group:localgov_menu_link_group
   - localgov_page_components:localgov_page_components
   - localgov_paragraphs:localgov_paragraphs

--- a/tests/src/Functional/LocalGovProfileTest.php
+++ b/tests/src/Functional/LocalGovProfileTest.php
@@ -17,11 +17,11 @@ class LocalGovProfileTest extends BrowserTestBase {
   protected $profile = 'localgov';
 
   /**
-   * Test core modules enabled and uninstallable.
+   * Test localgov profile was installed and basic site functions.
    */
   public function testLocalGovDrupalProfile() {
 
-    // Test core modules enabled and uninstallable.
+    // Test localgov_core module is enabled and is not uninstallable.
     $this->assertTrue($this->container->get('module_handler')->moduleExists('localgov_core'));
     try {
       $this->container->get('module_installer')->uninstall(['localgov_core']);
@@ -30,6 +30,9 @@ class LocalGovProfileTest extends BrowserTestBase {
     catch (ModuleUninstallValidatorException $e) {
       $this->assertContains('module is required', $e->getMessage());
     }
+
+    // Test localgov_core:localgov_roles submodule is enabled.
+    $this->assertTrue($this->container->get('module_handler')->moduleExists('localgov_roles'));
 
     // Test front page loads after site install.
     $this->drupalGet('<front>');


### PR DESCRIPTION
Restarting pull request process because branch 'feature/150-enable-localgov-roles-submodule-on-install' is not available from Packagist to run the tests.  Hoping that restarting recreates the requirements.

Previous pr was closed:  https://github.com/localgovdrupal/localgov/pull/168

Added localgov_roles submodule to install section of localgov.info.yml.

Added test to LocalGovProfileTest.php checking the submodule has been enabled and added, improved and synced comments with code.

Merged recent PHP7.4 and Github testing template changes from master.