### PR TITLE
Update Admin Toolbar to version 3 on 2.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "drupal/admin_toolbar": "^2.2",
+        "drupal/admin_toolbar": "^3.0",
         "drupal/core": "^9.1",
         "drupal/devel": "^4.1",
         "drupal/gin": "3.0.0-alpha34",


### PR DESCRIPTION
**Observations**

- I noticed that when admin_toolbar_search is enabled and Gin is the administration theme, the search input only displays on the admin index page. 