### PR TITLE
Patch Drupal core to fix breadcrumb assertions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
             "drupal/core": {
                 "Fix for narrow forms on node/add screens, which is included in 9.2. See https://www.drupal.org/project/drupal/issues/3184667": "https://www.drupal.org/files/issues/2021-04-16/3184667.26.patch",
                 "Fix tests running with paratest. See https://www.drupal.org/project/drupal/issues/3192365": "https://www.drupal.org/files/issues/2021-01-12/3192365-3.patch",
-                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2021-06-09/2845144_52.patch"
+                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2021-06-09/2845144_52.patch",
+                "Breadcrumb assertions should not rely on CSS classes": "https://www.drupal.org/files/issues/2021-11-08/3248309-2.patch"
             },
             "drupal/gin_login": {
                 "Fix schema for gin_toolbar, see https://www.drupal.org/project/gin_login/issues/3192526": "https://www.drupal.org/files/issues/2021-01-13/gin_login-config_schema-3192526-8.patch"


### PR DESCRIPTION
AssertBreadcrumbTrait::getBreadcrumbParts expects the breadcrumb wrapper to have a specific CSS class, when this isn't the case the test fails even if the breadcrumb exists. This patch tries to match the breadcrumb by looking for an aria attribute which should means tests can pass on most themes.

See https://www.drupal.org/project/drupal/issues/3248309.

Closes #402 