### PR TITLE
Work round skipped search_api update, add new patch for search_api schema fix: #396

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal/gin_login": "^1.0@RC",
         "drupal/gin_toolbar": "^1.0@beta",
         "drupal/simple_sitemap": "^3.7",
-        "drupal/search_api": "1.20",
+        "drupal/search_api": "^1.21",
         "drush/drush": ">=10",
         "localgovdrupal/localgov_alert_banner": "^1.2.0",
         "localgovdrupal/localgov_base": "^1.0.0",
@@ -63,7 +63,7 @@
                 "Fix schema for gin_toolbar, see https://www.drupal.org/project/gin_login/issues/3192526": "https://www.drupal.org/files/issues/2021-01-13/gin_login-config_schema-3192526-8.patch"
             },
             "drupal/search_api": {
-                "Fix exported schema for search_api views, see https://www.drupal.org/project/search_api/issues/3196990": "https://www.drupal.org/files/issues/2021-05-10/3196990-10--views_wrong_query_type.patch"
+                "Fix schema for search_api views, see https://www.drupal.org/project/search_api/issues/3196990": "https://www.drupal.org/files/issues/2021-11-13/3196990-15-wrong_query_type.patch"
             }
         }
     }

--- a/localgov.install
+++ b/localgov.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\user\Entity\User;
+use Drupal\search_api\Entity\TaskStorageSchema;
 
 /**
  * Implements hook_install().
@@ -20,4 +21,19 @@ function localgov_install() {
   $user = User::load(1);
   $user->roles[] = 'administrator';
   $user->save();
+}
+
+/**
+ * Run the potentially skipped search_api_update_8107() safely.
+ */
+function localgov_update_8201() {
+  $module_handler = \Drupal::moduleHandler();
+  if ($module_handler->moduleExists('search_api')) {
+    $manager = \Drupal::entityDefinitionUpdateManager();
+    $entity_type = $manager->getEntityType('search_api_task');
+    if ($entity_type->getHandlerClass('storage_schema') != TaskStorageSchema::class) {
+      $entity_type->setHandlerClass('storage_schema', TaskStorageSchema::class);
+      $manager->updateEntityType($entity_type);
+    }
+  }
 }


### PR DESCRIPTION
https://github.com/localgovdrupal/localgov/issues/396

 * Rather than try and play with schema numbering as it was this profile
   that included the search_api patch, this module can run the
   search_api update. It runs before search_api further updates.
 * The new search_api patch, includes tests, and uses a post_update
   hook. If Thomas still moves it back to and update hook that's fine as
   it can be run more than once.