### PR TITLE
Gin settings changes for 8.x-3.0-beta1

### DIFF
--- a/config/install/gin.settings.yml
+++ b/config/install/gin.settings.yml
@@ -1,18 +1,20 @@
-preset_accent_color: blue
-preset_focus_color: gin
-enable_darkmode: '0'
-classic_toolbar: horizontal
-high_contrast_mode: false
-show_user_theme_settings: false
-third_party_settings:
-  shortcut:
-    module_link: true
+favicon:
+  use_default: true
 features:
-  node_user_picture: true
   comment_user_picture: true
   comment_user_verification: true
   favicon: true
-favicon:
-  use_default: true
+  node_user_picture: true
+third_party_settings:
+  shortcut:
+    module_link: true
+preset_accent_color: blue
+preset_focus_color: gin
+enable_darkmode: false
+classic_toolbar: horizontal
+icon_default: true
+high_contrast_mode: false
 accent_color: ''
 focus_color: ''
+icon_upload: ''
+show_user_theme_settings: false

--- a/config/install/gin.settings.yml
+++ b/config/install/gin.settings.yml
@@ -10,11 +10,9 @@ third_party_settings:
     module_link: true
 preset_accent_color: blue
 preset_focus_color: gin
-enable_darkmode: false
+enable_darkmode: '0'
 classic_toolbar: horizontal
-icon_default: true
 high_contrast_mode: false
 accent_color: ''
 focus_color: ''
-icon_upload: ''
 show_user_theme_settings: false

--- a/config/install/gin.settings.yml
+++ b/config/install/gin.settings.yml
@@ -1,9 +1,7 @@
 preset_accent_color: blue
 preset_focus_color: gin
-enable_darkmode: false
+enable_darkmode: '0'
 classic_toolbar: horizontal
-icon_default: true
-icon_path: ''
 high_contrast_mode: false
 show_user_theme_settings: false
 third_party_settings:
@@ -18,4 +16,3 @@ favicon:
   use_default: true
 accent_color: ''
 focus_color: ''
-icon_upload: ''


### PR DESCRIPTION
Updating Git settings to reflect Gin 8.x-3.0-beta1 config schema.

[Latest schema](https://git.drupalcode.org/project/gin/-/blob/8.x-3.0-beta1/config/schema/gin.schema.yml)