### PR TITLE
[#449] Fixed cannot apply drupal/core patches for Drupal 9.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,9 +55,8 @@
         },
         "patches": {
             "drupal/core": {
-                "Fix for narrow forms on node/add screens, which is included in 9.2. See https://www.drupal.org/project/drupal/issues/3184667": "https://www.drupal.org/files/issues/2021-04-16/3184667.26.patch",
                 "Fix tests running with paratest. See https://www.drupal.org/project/drupal/issues/3192365": "https://www.drupal.org/files/issues/2021-01-12/3192365-3.patch",
-                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2021-06-09/2845144_52.patch"
+                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2022-06-17/2845144-67.patch"
             },
             "drupal/gin_login": {
                 "Fix schema for gin_toolbar, see https://www.drupal.org/project/gin_login/issues/3192526": "https://www.drupal.org/files/issues/2021-01-13/gin_login-config_schema-3192526-8.patch"


### PR DESCRIPTION
Issue: https://github.com/localgovdrupal/localgov/issues/449

Tasks:
- Removed patch: 'Fix for narrow forms on node/add screens ...'
- Update new version for patch: 'Users can't reference unpublished content ...'