### PR TITLE
Feature/176 localgov generator tag

### DIFF
--- a/localgov.profile
+++ b/localgov.profile
@@ -15,7 +15,7 @@ function localgov_page_attachments(array &$attachments): void {
 
     if ($name == 'system_meta_generator') {
       $tag = &$html_head[0];
-      $tag['#attributes']['content'] = 'Drupal ' . $core_version[0] . ' (LocalGov Drupal | https://localgovdrupal.org)';
+      $tag['#attributes']['content'] = 'Drupal ' . $parts[0] . ' (LocalGov Drupal | https://localgovdrupal.org)';
     }
   }
 }

--- a/localgov.profile
+++ b/localgov.profile
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @file
+ * Enables modules and site configuration for a Localgov site installation.
+ */
+
+
+/**
+ * Implements hook_page_attachments().
+ */
+function localgov_page_attachments(array &$attachments): void {
+  foreach ($attachments['#attached']['html_head'] as &$html_head) {
+    $name = $html_head[1];
+    $core_version = \Drupal::VERSION;
+    $parts = explode('.', $core_version);
+
+    if ($name == 'system_meta_generator') {
+      $tag = &$html_head[0];
+      $tag['#attributes']['content'] = 'Drupal ' . $core_version[0] . ' (LocalGov Drupal | https://localgovdrupal.org)';
+    }
+  }
+}

--- a/localgov.profile
+++ b/localgov.profile
@@ -4,7 +4,6 @@
  * Enables modules and site configuration for a Localgov site installation.
  */
 
-
 /**
  * Implements hook_page_attachments().
  */

--- a/localgov.profile
+++ b/localgov.profile
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Enables modules and site configuration for a Localgov site installation.


### PR DESCRIPTION
<img width="1045" alt="Cursor_and_view-source_https___localgov-dev_ddev_site" src="https://github.com/localgovdrupal/localgov/assets/1036167/e7ae84ec-a97f-444a-8780-dfe9fb7cd8b7">


I've added the `\Drupal::Version` which returns the specific version so we don't need to mess about for 9 or 10 or even 11 again. 

This is related to https://github.com/localgovdrupal/localgov_core/issues/176
So https://github.com/localgovdrupal/localgov_core/pull/177 can be closed as discussed its better to have in the profile.