### PR TITLE
[3.x] Update gin_login to 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "drupal/content_lock": "^2.3",
         "drupal/core": "^10.0",
         "drupal/gin": "^3.0@alpha",
-        "drupal/gin_login": "^1.0@RC",
+        "drupal/gin_login": "^2.0.3",
         "drupal/gin_toolbar": "^1.0@beta",
         "drupal/preview_link": "^2.1@alpha",
         "drupal/simple_sitemap": "^4.1",


### PR DESCRIPTION
Fix #633

Gin login 1.x no longer supported.