### PR TITLE
Patch entity_browser to address PHP 8.2 test failures.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "drupal/gin": "^3.0@alpha",
         "drupal/gin_login": "^1.0@RC",
         "drupal/gin_toolbar": "^1.0@beta",
+        "drupal/entity_browser": "^2.9",
         "drupal/preview_link": "^2.1@alpha",
         "drupal/simple_sitemap": "^4.1",
         "drupal/search_api": "^1.21",

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,9 @@
         "patches": {
             "drupal/core": {
                 "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2022-06-17/2845144-67.patch"
+            },
+            "drupal/entity_browser": {
+              "Fix PHP 8.2 deprecation issue with WidgetSelectorBase-class, https://www.drupal.org/project/entity_browser/issues/3350169": "https://www.drupal.org/files/issues/2023-06-15/3350169-8_0.patch"
             }
         }
     }


### PR DESCRIPTION
Trying to fix the failing test in https://github.com/localgovdrupal/localgov/actions/runs/6801391950/job/18492295931?pr=636