### PR TITLE
Set PHP 8.1 as minimum PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "localgovdrupal/localgov_subsites": "^2.3.0",
         "localgovdrupal/localgov_scarfolk": "^1.1.2",
         "localgovdrupal/localgov_workflows": "^1.2.0",
-        "php": ">=8.1.0",
+        "php": ">=8.1.0"
     },
     "require-dev": {
         "drupal/core-dev": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "localgovdrupal/localgov_step_by_step": "^2.1.0",
         "localgovdrupal/localgov_subsites": "^2.3.0",
         "localgovdrupal/localgov_scarfolk": "^1.1.2",
-        "localgovdrupal/localgov_workflows": "^1.2.0"
+        "localgovdrupal/localgov_workflows": "^1.2.0",
+        "php": ">=8.1.0",
     },
     "require-dev": {
         "drupal/core-dev": "^10.0",


### PR DESCRIPTION
Fix #463 

Specify minimum PHP version in composer.json like Drupal core.