### PR TITLE
Update to latest version of the unpublised content access patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
                 "Fix PHP 8.2 deprecation notices": "https://www.drupal.org/files/issues/2023-05-22/3343964-5.patch"
             },
             "drupal/core": {
-                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-01-07/2845144-78.patch"
+                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch"
             }
         }
     }


### PR DESCRIPTION
Fix #670

Uses the patch in comment 87.
This is the evolution of our current patch, rather than the shortned version.
