### PR TITLE
Use the latest dev version of Preview Link as this includes an admin UI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal/gin_login": "^2.0.3",
         "drupal/gin_toolbar": "^1.0@beta",
         "drupal/entity_browser": "^2.9",
-        "drupal/preview_link": "^2.1@alpha",
+        "drupal/preview_link": "dev-2.1.x#9c6d111d as 2.1-alpha3",
         "drupal/simple_sitemap": "^4.1",
         "drupal/search_api": "^1.21",
         "drush/drush": ">=10",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal/gin_login": "^2.0.3",
         "drupal/gin_toolbar": "^1.0@beta",
         "drupal/entity_browser": "^2.9",
-        "drupal/preview_link": "dev-2.1.x#9c6d111d as 2.1-alpha3",
+        "drupal/preview_link": "dev-2.1.x#9c6d111d",
         "drupal/simple_sitemap": "^4.1",
         "drupal/search_api": "^1.21",
         "drush/drush": ">=10",


### PR DESCRIPTION
The latest dev version of Preview Link includes an admin UI: https://www.drupal.org/project/preview_link/issues/3156692

This allows people to turn the multiple page feature on and off.

I have asked for a new [release of Preview Link](https://www.drupal.org/project/preview_link/releases) and if we get one this PR is unnecessary.

Part of #600