### PR TITLE
Added LocalGov Preview Link module

### DIFF
--- a/modules/localgov_preview_link/README.md
+++ b/modules/localgov_preview_link/README.md
@@ -1,0 +1,3 @@
+# LocalGov Drupal Preview Link
+
+Enhancements to Preview Link functionality for LocalGov Drupal.

--- a/modules/localgov_preview_link/localgov_preview_link.info.yml
+++ b/modules/localgov_preview_link/localgov_preview_link.info.yml
@@ -1,0 +1,7 @@
+name: 'LocalGov Drupal Preview Link'
+type: module
+description: 'LocalGov Drupal enhancements for the Preview Link module.'
+package: LocalGov Drupal
+core_version_requirement: ^10 || ^11
+dependencies:
+  - preview_link:preview_link

--- a/modules/localgov_preview_link/localgov_preview_link.install
+++ b/modules/localgov_preview_link/localgov_preview_link.install
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the localgov_preview_link module.
+ */

--- a/modules/localgov_preview_link/localgov_preview_link.module
+++ b/modules/localgov_preview_link/localgov_preview_link.module
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for localgov_preview_link module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_FORM_ID_alter() for preview_link_entity_form.
+ */
+function localgov_preview_link_form_preview_link_entity_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
+
+  /** @var \Drupal\localgov_preview_link\AutofillPreviewLinksInterface $autofill_service */
+  $autofill_service = \Drupal::service('localgov_preview_link.autofill');
+
+  if (!$autofill_service->isSupported()) {
+    return;
+  }
+
+  $form['autofill'] = [
+    '#type' => 'submit',
+    '#value' => t('Add all of the pages for this ' . $autofill_service->getLabel()),
+    '#submit' => ['localgov_preview_link_form_preview_link_entity_form_alter_submit'],
+    '#weight' => -10,
+  ];
+}
+
+/**
+ * Submit handler to autofill the preview link entities.
+ */
+function localgov_preview_link_form_preview_link_entity_form_alter_submit($form, FormStateInterface $form_state): void {
+
+  $autofill_service = \Drupal::service('localgov_preview_link.autofill');
+  $autofill_service->autofillPreviewLinks($form, $form_state);
+}

--- a/modules/localgov_preview_link/localgov_preview_link.services.yml
+++ b/modules/localgov_preview_link/localgov_preview_link.services.yml
@@ -1,0 +1,4 @@
+services:
+  localgov_preview_link.autofill:
+    class: Drupal\localgov_preview_link\AutofillPreviewLinks
+    arguments: ['@current_route_match']

--- a/modules/localgov_preview_link/src/AutofillPreviewLinks.php
+++ b/modules/localgov_preview_link/src/AutofillPreviewLinks.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Drupal\localgov_preview_link;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\NodeInterface;
+use Drupal\preview_link\Entity\PreviewLink;
+
+/**
+ * Utility class for autofilling preview links.
+ */
+class AutofillPreviewLinks implements AutofillPreviewLinksInterface {
+
+  /**
+   * Supported content types.
+   *
+   * @var array
+   */
+  protected array $supportedContentTypes = [
+    'guide' => [
+      'localgov_guides_overview',
+      'localgov_guides_page',
+    ],
+  ];
+
+  /**
+   * The current route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface $routeMatch;
+   */
+  protected RouteMatchInterface $routeMatch;
+
+  /**
+   * The entity being previewed.
+   *
+   * @var \Drupal\Core\Entity\ContentEntityInterface|NULL
+   */
+  protected ?ContentEntityInterface $entity = NULL;
+
+  /**
+   * Constructs an AutofillPreviewLinks object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match service.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
+
+    // Get the entity being previewed.
+    $entityParameterName = $this->routeMatch->getRouteObject()->getOption('preview_link.entity_type_id');
+    if (!is_null($entityParameterName)) {
+      $this->entity = $this->routeMatch->getParameter($entityParameterName);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isSupported(): bool {
+    if (!is_null($this->entity)) {
+      $bundle = $this->entity->bundle();
+      foreach ($this->supportedContentTypes as $bundles) {
+        if (in_array($bundle, $bundles)) {
+          return TRUE;
+        }
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntity(): ?ContentEntityInterface {
+    return $this->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLabel(): string {
+    if (!is_null($this->entity)) {
+      $bundle = $this->entity->bundle();
+      foreach ($this->supportedContentTypes as $label => $bundles) {
+        if (in_array($bundle, $bundles)) {
+          return $label;
+        }
+      }
+    }
+
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function autofillPreviewLinks(&$form, FormStateInterface $form_state): void {
+    if (is_null($this->entity)) {
+      return;
+    }
+
+    $preview_link = $form_state->getFormObject()->getEntity();
+    if (!$preview_link instanceof PreviewLink) {
+      return;
+    }
+
+    // Get all entities to be previewed.
+    $entities = [];
+    $bundle = $this->entity->bundle();
+    if ($bundle == 'localgov_guides_overview' || $bundle == 'localgov_guides_page') {
+      $entities = $this->getGuideNodes($this->entity);
+    }
+
+    // Add entities to preview link.
+    $current_entities = $preview_link->getEntities();
+    foreach ($entities as $entity) {
+      $found = FALSE;
+      foreach ($current_entities as $current_entity) {
+        if ($current_entity->id() == $entity->id()) {
+          $found = TRUE;
+          break;
+        }
+      }
+      if (!$found) {
+        $preview_link->addEntity($entity);
+      }
+    }
+    $preview_link->save();
+  }
+
+  /**
+   * Get all the nodes that belong to a guide.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The guide to get nodes for.
+   *
+   * @return \Drupal\node\NodeInterface[]
+   */
+  protected function getGuideNodes(NodeInterface $node): array {
+    $guide_nodes = [];
+
+    // Find guide overview.
+    if ($node->bundle() == 'localgov_guides_overview') {
+      $overview = $node;
+    }
+    elseif ($node->bundle() == 'localgov_guides_page') {
+      $overview = $node->get('localgov_guides_parent')->entity;
+    }
+    $guide_nodes[] = $overview;
+
+    // Find guide pages.
+    $guide_pages = $overview->get('localgov_guides_pages')->referencedEntities();
+    foreach ($guide_pages as $guide_page) {
+      if ($guide_page instanceof NodeInterface && $guide_page->access('view')) {
+        $guide_nodes[] = $guide_page;
+      }
+    }
+
+    return $guide_nodes;
+  }
+
+}

--- a/modules/localgov_preview_link/src/AutofillPreviewLinksInterface.php
+++ b/modules/localgov_preview_link/src/AutofillPreviewLinksInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\localgov_preview_link;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Interface for autofilling preview links.
+ */
+interface AutofillPreviewLinksInterface {
+
+  /**
+   * Is the entity being previewed supported by this module?
+   *
+   * @return bool
+   *   TRUE if the entity is supported, FALSE otherwise.
+   */
+  public function isSupported(): bool;
+
+  /**
+   * Get the entity being previewed.
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface|NULL
+   */
+  public function getEntity(): ?ContentEntityInterface;
+
+  /**
+   * Get label.
+   *
+   * @return string
+   *   The label to use for the preview link entity.
+   */
+  public function getLabel(): string;
+
+  /**
+   * Populate entities in preview link form.
+   */
+  public function autofillPreviewLinks(&$form, FormStateInterface $form_state): void;
+}


### PR DESCRIPTION
This PR adds a new module that makes it easy for content editors to add all pages in a guide or step by step to a preview link.

The module adds a new button that will auto-populate the entities on a preview link page.

![image](https://github.com/localgovdrupal/localgov/assets/7189914/ea30091d-ab58-41bf-b1cb-2ea0d703aaff)


Part of #600