### PR TITLE
Remove content_lock patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "drupal/admin_toolbar": "^3.0",
-        "drupal/content_lock": "^2.3",
+        "drupal/content_lock": "^2.4",
         "drupal/core": "^10.0",
         "drupal/gin": "^3.0@alpha",
         "drupal/gin_login": "^2.0.3",
@@ -57,9 +57,6 @@
             "drupal/core": "-p2"
         },
         "patches": {
-	    "drupal/content_lock": {
-                "Fix PHP 8.2 deprecation notices": "https://www.drupal.org/files/issues/2023-05-22/3343964-5.patch"
-            },
             "drupal/core": {
                 "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch"
             }


### PR DESCRIPTION
Removing the content_lock patch as this is included in v2.4 of content_lock and revised the requirement for content_lock to ^2.4

See issue https://github.com/localgovdrupal/localgov/issues/709

And Slack conversation: https://localgovdrupal.slack.com/archives/CSE44GLSE/p1715953228601509