### PR TITLE
adds 'copy-to-clipboard' button for preview_link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
                 "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch"
             },
             "drupal/preview_link": {
-                "Add a 'copy to clipboard' feature for preview_link": "https://git.drupalcode.org/project/preview_link/-/merge_requests/29/diffs.diff"
+                "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-05-27/3449121-7.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
         "patches": {
             "drupal/core": {
                 "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch"
+            },
+            "drupal/preview_link": {
+                "Add a 'copy to clipboard' feature for preview_link": "https://git.drupalcode.org/project/preview_link/-/merge_requests/29/diffs.diff"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
                 "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch"
             },
             "drupal/preview_link": {
-                "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-05-27/3449121-7.patch"
+                "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-05-28/3449121-9.patch"
             }
         }
     }


### PR DESCRIPTION
Closes #722 

Here's a PR for #722, while we are waiting on the patch sent to Drupal.org to be committed.

===
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.