### PR TITLE
fix: config type breaking tests

### DIFF
--- a/config/install/system.cron.yml
+++ b/config/install/system.cron.yml
@@ -1,4 +1,4 @@
 threshold:
   requirements_warning: 172800
   requirements_error: 1209600
-logging: 1
+logging: true


### PR DESCRIPTION
Once https://github.com/localgovdrupal/drupal-container/pull/33 and the other `drupal-container` PRs are merged and a new docker image is created for each PHP version, this PR will fix the error below which is reported in tests across ~21 modules.

```
1) Drupal\Tests\localgov_content_lock\Functional\ContentLockTest::testContentLockConfiguration
Drupal\Core\Config\Schema\SchemaIncompleteException: Schema errors for system.cron with the following errors: system.cron:logging variable type is integer but applied schema class is Drupal\Core\TypedData\Plugin\DataType\BooleanData

/app/web/core/lib/Drupal/Core/Config/Development/ConfigSchemaChecker.php:98
/app/web/core/lib/Drupal/Component/EventDispatcher/ContainerAwareEventDispatcher.php:111
/app/web/core/lib/Drupal/Core/Config/Config.php:230
/app/web/core/lib/Drupal/Core/Config/ConfigInstaller.php:396
/app/web/core/lib/Drupal/Core/Config/ConfigInstaller.php:149
/app/web/core/lib/Drupal/Core/ProxyClass/Config/ConfigInstaller.php:75
/app/web/core/lib/Drupal/Core/Extension/ModuleInstaller.php:326
/app/web/core/lib/Drupal/Core/ProxyClass/Extension/ModuleInstaller.php:83
/app/web/core/includes/install.inc:567
/app/web/core/includes/install.core.inc:1125
/app/web/core/includes/install.core.inc:695
/app/web/core/includes/install.core.inc:572
/app/web/core/includes/install.core.inc:122
/app/web/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php:315
/app/web/core/tests/Drupal/Tests/BrowserTestBase.php:570
/app/web/core/tests/Drupal/Tests/BrowserTestBase.php:370
/app/web/profiles/contrib/localgov/modules/localgov_content_lock/tests/src/Functional/ContentLockTest.php:33
/app/vendor/phpunit/phpunit/src/Framework/TestResult.php:729
```