### PR TITLE
fix: change uninstall string check to boolean check

### DIFF
--- a/tests/src/Functional/LocalGovProfileTest.php
+++ b/tests/src/Functional/LocalGovProfileTest.php
@@ -33,7 +33,8 @@ class LocalGovProfileTest extends BrowserTestBase {
       $this->fail('Uninstalled localgov_core module.');
     }
     catch (ModuleUninstallValidatorException $e) {
-      $this->assertStringContainsString('module is required', $e->getMessage());
+      $hasError = strlen($e->getMessage()) > 0 ? TRUE : FALSE;
+      $this->assertTrue($hasError);
     }
 
     // Test localgov_core:localgov_roles submodule is enabled.


### PR DESCRIPTION
This fixes the following error:

```
1) Drupal\Tests\localgov\Functional\LocalGovProfileTest::testLocalGovDrupalProfile
Failed asserting that 'The following reasons prevent the modules from being uninstalled: The 'LocalGov Drupal' install profile requires 'LocalGov Core'; The install profile 'LocalGov Drupal' is providing the following module(s): localgov_login_redirect' contains "module is required".

/var/www/html/vendor/phpunit/phpunit/src/Framework/Constraint/Constraint.php:122
/var/www/html/vendor/phpunit/phpunit/src/Framework/Constraint/Constraint.php:56
/var/www/html/web/profiles/contrib/localgov/tests/src/Functional/LocalGovProfileTest.php:36
/var/www/html/vendor/phpunit/phpunit/src/Framework/TestResult.php:729
```

Prior to Drupal 10.3 the assert check was checking the error message contains `module is required`, with Drupal 10.3 the error message does not contain this string and is much longer.

```
The following reasons prevent the modules from being uninstalled: The 'LocalGov Drupal' install profile requires 'LocalGov Core'; The install profile 'LocalGov Drupal' is providing the following module(s): localgov_login_redirect
```

This PR changes the check to use a boolean and just checking if an error message exists.

The failure in the workflow that paratest hides the true error message, is fixed in a previous PR https://github.com/localgovdrupal/localgov/pull/736