### PR TITLE
Adds new install step, which calls a new hook.

### DIFF
--- a/localgov.api.php
+++ b/localgov.api.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Run a task during the site installation process.
+ *
+ * This is intended for work that needs to happen when installing a localgov
+ * site, that can't happen in a module's hook_install(). This hook is invoked
+ * later in the install process, when everything bar the importing of
+ * translations is done.
+ *
+ * It can also be used to only run code during a site install, and not when a
+ * module is installed in an existing site.
+ */
+function hook_localgov_post_install() {
+
+}

--- a/localgov.api.php
+++ b/localgov.api.php
@@ -1,6 +1,16 @@
 <?php
 
 /**
+ * @file
+ * Hooks provided by the LocalGov install profile.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
  * Run a task during the site installation process.
  *
  * This is intended for work that needs to happen when installing a localgov
@@ -11,6 +21,10 @@
  * It can also be used to only run code during a site install, and not when a
  * module is installed in an existing site.
  */
-function hook_localgov_post_install() {
-
+function hook_localgov_post_install(): void {
+  // Whatever your module needs to do goes here.
 }
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/localgov.profile
+++ b/localgov.profile
@@ -21,7 +21,6 @@ function localgov_page_attachments(array &$attachments): void {
   }
 }
 
-
 /**
  * Implements hook_install_tasks().
  */

--- a/localgov.profile
+++ b/localgov.profile
@@ -20,3 +20,29 @@ function localgov_page_attachments(array &$attachments): void {
     }
   }
 }
+
+
+/**
+ * Implements hook_install_tasks().
+ */
+function localgov_install_tasks(array &$install_state): array {
+  return [
+    'localgov_post_install_task' => [
+      'display_name' => t('Localgov post install'),
+      'display' => TRUE,
+    ],
+  ];
+}
+
+/**
+ * This is an install step, added by localgov_install_tasks().
+ *
+ * We use this step to call a hook to allow other localgov modules to set things
+ * up as part of the site installation process that they can't do in their
+ * install hooks.
+ */
+function localgov_post_install_task(): void {
+  \Drupal::moduleHandler()->invokeAllWith('localgov_post_install', function (callable $hook, string $module) {
+    $hook();
+  });
+}


### PR DESCRIPTION
## What does this change?

Adds a new step to the installer, which calls a new hook (hook_localgov_post_install) to let other modules perform tasks.

## How to test

Use the version of localgov_core from this MR: https://github.com/localgovdrupal/localgov_core/pull/212. That will implement the hook in this MR and use it to set up blocks in the installer.