### PR TITLE
Compatibility with Workspaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,11 +67,11 @@
                 "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-05-28/3449121-9.patch"
             },
             "drupal/pathauto": {
-                "Allow path generation inside of a workspace - and importantly don't regenerate when publishing space": "https://www.drupal.org/files/issues/2024-04-08/3283769-10.patch"
+                "Allow path generation inside of a workspace - and importantly don't regenerate when publishing space https://www.drupal.org/project/pathauto/issues/3283769": "https://www.drupal.org/files/issues/2024-04-08/3283769-10.patch"
             },
             "drupal/redirect": {
                 "Validation issue on adding url redirect: https://www.drupal.org/project/redirect/issues/3057250": "https://www.drupal.org/files/issues/2022-09-01/3057250-53.patch",
-                "Create redirect from path alias change and workspaces": "https://www.drupal.org/files/issues/2024-03-18/3431260.patch"
+                "Create redirect from path alias change and workspaces https://www.drupal.org/project/redirect/issues/3431260": "https://www.drupal.org/files/issues/2024-03-18/3431260.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -59,14 +59,19 @@
         },
         "patches": {
             "drupal/core": {
-                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch"
+                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch",
+                "Content moderation and Workspaces https://www.drupal.org/project/drupal/issues/3179199#comment-15711680": "./patches/drupal_core/3179199-3132022-content-moderation-workspaces-query.patch"
             },
             "drupal/preview_link": {
                 "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",
                 "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-05-28/3449121-9.patch"
             },
+            "drupal/pathauto": {
+                "Allow path generation inside of a workspace - and importantly don't regenerate when publishing space": "https://www.drupal.org/files/issues/2024-04-08/3283769-10.patch"
+            },
             "drupal/redirect": {
-                "Validation issue on adding url redirect: https://www.drupal.org/project/redirect/issues/3057250": "https://www.drupal.org/files/issues/2022-09-01/3057250-53.patch"
+                "Validation issue on adding url redirect: https://www.drupal.org/project/redirect/issues/3057250": "https://www.drupal.org/files/issues/2022-09-01/3057250-53.patch",
+                "Create redirect from path alias change and workspaces": "https://www.drupal.org/files/issues/2024-03-18/3431260.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
                 "Allow path generation inside of a workspace - and importantly don't regenerate when publishing space https://www.drupal.org/project/pathauto/issues/3283769": "https://www.drupal.org/files/issues/2024-04-08/3283769-10.patch"
             },
             "drupal/redirect": {
-                "Create redirect from path alias change and workspaces https://www.drupal.org/project/redirect/issues/3431260": "https://www.drupal.org/files/issues/2024-03-18/3431260.patch"
+                "Create redirect from path alias change and workspaces https://www.drupal.org/project/redirect/issues/3431260": "https://www.drupal.org/files/issues/2024-03-18/3431260.patch",
                 "Validation issue on adding url redirect: https://www.drupal.org/project/redirect/issues/3057250": "https://www.drupal.org/files/issues/2024-08-11/redirect--2024-08-11--3057250-79.patch"
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "patches": {
             "drupal/core": {
                 "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch",
-                "Content moderation and Workspaces https://www.drupal.org/project/drupal/issues/3179199#comment-15711680": "./patches/drupal_core/3179199-3132022-content-moderation-workspaces-query.patch"
+                "Content moderation and Workspaces https://www.drupal.org/project/drupal/issues/3179199#comment-15711680": "https://www.drupal.org/files/issues/2024-08-11/3179199-3132022-content-moderation-workspaces-query.patch"
             },
             "drupal/preview_link": {
                 "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",


### PR DESCRIPTION
## What does this change?

Workspaces has issues with core, pathauto, and redirect that are experienced with LocalGov Drupal.

### Core

https://www.drupal.org/project/drupal/issues/3179199

Most commonly the automatically created pathauto revision id will clash with a previous revision id of some content that is being published, causing (because of not checking entity type with revision id) an erroneous error that there is content in  a non-default workflow state in the space. Very confusing.

#### How to test

Automated tests on the patch. Manual steps (I'd advise the last one) to reproduce on the issue.

### Pathauto

https://www.drupal.org/project/pathauto/issues/3283769

Main problem experienced in manual testing with LGD was when something with a path pattern dependent on a parent (like services parent) was in a space that was published the paths were regenerated and the parent path would be /node/123 at the point of publishing, so the child ended up with node/123/child-title. With the patch paths are generated in the space, and not regenerated when the space is published.

#### How to test

Tediously create content in spaces with paths that depend on a parent till it goes wrong.

### Redirect

https://www.drupal.org/project/redirect/issues/3431260

This one allows redirect to be somewhat workspaces aware. Notes on my earlier thoughts https://www.drupal.org/project/redirect/issues/3114103#comment-15714027 

#### How to test (and problem)

Create content in a space, then change its title. It will generate a redirect, but this will fail with a fatal error as it tries to create a redirect.

## How can we measure success?

Can use workspaces with LGD.

## Have we considered potential risks?

Issues don't change data structure, so should be fine to apply. If they stop applying or a different approach is taken we had Workspaces working till then and will have to move to any other fix.