### PR TITLE
updates patch for preview link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
             },
             "drupal/preview_link": {
                 "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",
-                "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-05-28/3449121-9.patch"
+                "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-08-15/3449121-10.patch"
             },
             "drupal/pathauto": {
                 "Allow path generation inside of a workspace - and importantly don't regenerate when publishing space https://www.drupal.org/project/pathauto/issues/3283769": "https://www.drupal.org/files/issues/2024-04-08/3283769-10.patch"


### PR DESCRIPTION
## What does this change?

Preview Link has had a new release, so I had to re-roll the patch that is against it for "Copy to clipboard". This updates the patch that we can now use.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.