### PR TITLE
Feature/779 remove content moderation workspaces patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,19 @@ This project is the Drupal installation profile that is best installed using
 composer to require a project template, [localgov_project]([url](https://github.com/localgovdrupal/localgov_project/)), to scaffold and build
 the codebase, which includes this installation profile.
 
+## Patches
+
+Please note, if you are using Drupal core < 10.3.6, you might want to apply
+this patch for content moderation and workspaces.
+
+ - [Patch](https://www.drupal.org/files/issues/2024-08-11/3179199-3132022-content-moderation-workspaces-query.patch)
+ - [Issue](https://www.drupal.org/project/drupal/issues/3179199#comment-15711680)
+
 ## Supported branches
 
 We are actively developing and supporting the 3.x branch for Drupal 10.
 
-The 2.x branch is no longer officially supported, as Drupal 9 is unsupported since 1st November 2023. 
+The 2.x branch is no longer officially supported, as Drupal 9 is unsupported since 1st November 2023.
 We will continue to help our councils that have not yet upgraded to Drupal 10, on a best efforts basis.
 
 The 1.x branch is no longer actively supported and not recommended for new sites.
@@ -29,11 +37,11 @@ To install LocalGov Drupal locally you will need an appropriate versions of:
 
  - PHP (see https://www.drupal.org/docs/system-requirements/php-requirements)
  - A database server like MySQL (see https://www.drupal.org/docs/system-requirements/database-server-requirements)
- - A web server like Apache2 (see https://www.drupal.org/docs/system-requirements/web-server-requirements) 
+ - A web server like Apache2 (see https://www.drupal.org/docs/system-requirements/web-server-requirements)
 
-Many of us use the Lando file included to run a local docker environmnent for testing and development, but some people prefer to run the web servers natively on their host machine. 
+Many of us use the Lando file included to run a local docker environmnent for testing and development, but some people prefer to run the web servers natively on their host machine.
 
-We also include default DDEV configuration for developers that prefer DDEV. [Visit our DDEV docs page](https://docs.localgovdrupal.org/devs/getting-started/working-with-ddev.html#working-with-ddev) to see how to get set up. 
+We also include default DDEV configuration for developers that prefer DDEV. [Visit our DDEV docs page](https://docs.localgovdrupal.org/devs/getting-started/working-with-ddev.html#working-with-ddev) to see how to get set up.
 
 ### PHP requirements
 
@@ -41,12 +49,12 @@ We folllow Drupal's PHP recomendations: https://www.drupal.org/docs/system-requi
 
 We currently recomend PHP 8.1 also aim to support PHP PHP 8.2 in line with Drupal 10's PHP support.
 
-You will also need to have certain PHP extensions enabled (see https://www.drupal.org/docs/system-requirements/php-requirements#extensions) including: 
+You will also need to have certain PHP extensions enabled (see https://www.drupal.org/docs/system-requirements/php-requirements#extensions) including:
 
  - PHP mbstring
  - PHP cURL
  - GD library
- - XML 
+ - XML
 
 If you see errors when running composer require, double check your PHP extensions.
 
@@ -70,7 +78,7 @@ To install LocalGov Drupal locally for testing or development, use the
 Change `MY_PROJECT` to whatever you'd like your project directory to be called.
 
 ```bash
-composer create-project localgovdrupal/localgov-project:^3.0 MY_PROJECT --no-install 
+composer create-project localgovdrupal/localgov-project:^3.0 MY_PROJECT --no-install
 ```
 
 Change directory into the MY_PROJECT directory and run lando start.
@@ -87,9 +95,9 @@ lando composer install
 lando drush si localgov -y
 ```
 
-Note: As you might be running a different version of PHP on your host machine from the 
-version that Lando runs, it is advisable to run composer install from within Lando. 
-This ensures dependencies reflect the PHP version that the webserver is actually running. 
+Note: As you might be running a different version of PHP on your host machine from the
+version that Lando runs, it is advisable to run composer install from within Lando.
+This ensures dependencies reflect the PHP version that the webserver is actually running.
 
 ## Composer notes
 
@@ -97,7 +105,7 @@ If developing locally and you want to force composer to clone again
 from source rather than use composer cache, you can add the `--no-cache` flag.
 
 ```bash
-composer create-project localgovdrupal/localgov-project:^3.0 MY_PROJECT --no-cache  --no-install 
+composer create-project localgovdrupal/localgov-project:^3.0 MY_PROJECT --no-cache  --no-install
 ```
 
 If you just want to pull in the latest changes to LocalGov Drupal run composer
@@ -203,11 +211,11 @@ lando phpunit --filter=myTestName
 * [Drupal 8 testing documentation](https://www.drupal.org/docs/8/testing)
 * [Workshop: Automated Testing and Test Driven Development in Drupal 8](https://github.com/opdavies/workshop-drupal-automated-testing)
 
-## Security policy 
+## Security policy
 
-It is important to have a way to report security issues safely and securely. Luckily this is something Drupal has done very well for many years, via the security team. We publish our distributions on drupal.org and opt in to the [security advisory policy](https://www.drupal.org/security-advisory-policy).. 
+It is important to have a way to report security issues safely and securely. Luckily this is something Drupal has done very well for many years, via the security team. We publish our distributions on drupal.org and opt in to the [security advisory policy](https://www.drupal.org/security-advisory-policy)..
 
-See https://www.drupal.org/drupal-security-team/general-information 
+See https://www.drupal.org/drupal-security-team/general-information
 
 ### How to report a security issue
 
@@ -215,11 +223,11 @@ If you discover or learn about a potential error, weakness, or threat that can c
 
 ## Maintainers
 
-This project is currently maintained by: 
+This project is currently maintained by:
 
  - Andy Broomfield: https://www.drupal.org/u/andybroomfield
  - Ekes: https://www.drupal.org/u/ekes
  - Finn Lewis: https://www.drupal.org/u/finn-lewis
  - Maria Young: https://www.drupal.org/u/mariay-0
  - Mark Conroy: https://www.drupal.org/u/markconroy
- - Stephen Cox: https://www.drupal.org/u/stephen-cox 
+ - Stephen Cox: https://www.drupal.org/u/stephen-cox

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         "patches": {
             "drupal/core": {
                 "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch",
-                "Content moderation and Workspaces https://www.drupal.org/project/drupal/issues/3179199#comment-15711680": "https://www.drupal.org/files/issues/2024-08-11/3179199-3132022-content-moderation-workspaces-query.patch"
             },
             "drupal/preview_link": {
                 "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         },
         "patches": {
             "drupal/core": {
-                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch",
+                "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch"
             },
             "drupal/preview_link": {
                 "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Removes content moderation workspaces patch, committed to Drupal core and release as 10.3.6 

https://www.drupal.org/project/drupal/issues/3179199#comment-15782586

https://www.drupal.org/project/drupal/releases/10.3.6