### PR TITLE
Patch Preview Link for bug where references to other entities being previewed don't display

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
             },
             "drupal/preview_link": {
                 "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",
-                "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-08-15/3449121-10.patch"
+                "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-08-15/3449121-10.patch",
+                "References to other entities being previewed don't display #3481523": "https://www.drupal.org/files/issues/2024-10-18/3481523-4.patch"
             },
             "drupal/pathauto": {
                 "Allow path generation inside of a workspace - and importantly don't regenerate when publishing space https://www.drupal.org/project/pathauto/issues/3283769": "https://www.drupal.org/files/issues/2024-04-08/3283769-10.patch"


### PR DESCRIPTION
## What does this change?

Patched Preview Link for issue #771, drupal.org issue: https://www.drupal.org/project/preview_link/issues/3481523

The patch changes the node access hook so Preview Links access handler is run for all pages included in a preview link entity. Without the hook it only runs for the page being viewed.

## How to test

See https://github.com/localgovdrupal/localgov/issues/771#issuecomment-2373991933 on how to reproduce the issue this should fix.

## How can we measure success?

Previewing more than one page becomes easier and works as people expect.

## Have we considered potential risks?

This changes an access handler so has the potential to allow more than it should.
