### PR TITLE
Remove code to add non-existent administrator role.

### DIFF
--- a/localgov.install
+++ b/localgov.install
@@ -5,7 +5,6 @@
  * Install functions for the LocalGovInstall installation profile.
  */
 
-use Drupal\user\Entity\User;
 use Drupal\views\Entity\View;
 
 /**

--- a/localgov.install
+++ b/localgov.install
@@ -19,11 +19,6 @@ function localgov_install() {
 
   $config_factory = \Drupal::configFactory();
 
-  // Assign user 1 the "administrator" role.
-  $user = User::load(1);
-  $user->roles[] = 'administrator';
-  $user->save();
-
   // Disable the frontpage view.
   $frontpage_view = View::load('frontpage');
   $frontpage_view->setStatus(FALSE)->save();


### PR DESCRIPTION
We have added a localgov_admin role that is supplied by localgov_admin_role https://github.com/localgovdrupal/localgov_core/pull/234 and included in this profile https://github.com/localgovdrupal/localgov/commit/0d19a7cfa92fc3dbe6b4d7db7aff174292231a17 This role is added to user 1 by core (and drush) automatically as (the only) administrator role at the time of install.

Credit to @NikLP for spotting that there was a role on User 1 at time of install that was not actually a role on the site.