### PR TITLE
Sets form to no-validate, so we can use Drupal validation instead

### DIFF
--- a/localgov.profile
+++ b/localgov.profile
@@ -5,6 +5,8 @@
  * Enables modules and site configuration for a Localgov site installation.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_page_attachments().
  */
@@ -44,4 +46,11 @@ function localgov_post_install_task(): void {
   \Drupal::moduleHandler()->invokeAllWith('localgov_post_install', function (callable $hook, string $module) {
     $hook();
   });
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function localgov_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $form['#attributes']['novalidate'] = 'novalidate';
 }

--- a/localgov.profile
+++ b/localgov.profile
@@ -51,6 +51,6 @@ function localgov_post_install_task(): void {
 /**
  * Implements hook_form_alter().
  */
-function localgov_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function localgov_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
   $form['#attributes']['novalidate'] = 'novalidate';
 }


### PR DESCRIPTION
Closes #503 

## What does this change?

HTML 5 validation is not very good. Drupal's form validation is much better.

This simply removes HTML 5 validation from forms - same approach as [Disable HTML5 Validation](https://www.drupal.org/project/disable_html5_validation) module - so Drupal's form validation can take over instead.

Before:

![Screenshot 2024-12-18 at 14 07 16](https://github.com/user-attachments/assets/1d18fd67-277d-46be-903f-fba84d80629a)

After: 

![Screenshot 2024-12-18 at 14 06 15](https://github.com/user-attachments/assets/1242b505-48a7-4e7a-aa27-17087bafc78c)
