### PR TITLE
Set Preview Link expiry in days rather than seconds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
             "drupal/preview_link": {
                 "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",
                 "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-08-15/3449121-10.patch",
-                "References to other entities being previewed don't display #3481523": "https://www.drupal.org/files/issues/2024-10-18/3481523-4.patch"
+                "References to other entities being previewed don't display #3481523": "https://www.drupal.org/files/issues/2024-10-18/3481523-4.patch",
+                "Set Preview Link expiry in days #3510967": "https://www.drupal.org/files/issues/2025-03-04/3510967-3.patch"
             },
             "drupal/pathauto": {
                 "Allow path generation inside of a workspace - and importantly don't regenerate when publishing space https://www.drupal.org/project/pathauto/issues/3283769": "https://www.drupal.org/files/issues/2024-04-08/3283769-10.patch"

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
                 "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",
                 "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-08-15/3449121-10.patch",
                 "References to other entities being previewed don't display #3481523": "https://www.drupal.org/files/issues/2024-10-18/3481523-4.patch",
-                "Set Preview Link expiry in days #3510967": "https://www.drupal.org/files/issues/2025-03-04/3510967-3.patch"
+                "Set Preview Link expiry in days #3510967": "https://www.drupal.org/files/issues/2025-03-11/3510967-4.patch"
             },
             "drupal/pathauto": {
                 "Allow path generation inside of a workspace - and importantly don't regenerate when publishing space https://www.drupal.org/project/pathauto/issues/3283769": "https://www.drupal.org/files/issues/2024-04-08/3283769-10.patch"


### PR DESCRIPTION
Fixes  localgovdrupal/localgov_workflows#124

## What does this change?

Patches the Preview Link module so the expiry time for preview links is set by days rather than seconds.

## How to test

Go to /admin/config/content/preview_link and change the preview link expiry in days.
