### PR TITLE
Add localgov_utilities module that includes character counting for titles and summary fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "drupal/gin_toolbar": "^1.0 || ^2.0",
         "drupal/entity_browser": "^2.9",
         "drupal/disable_html5_validation": "^2.0",
+        "drupal/localgov_utilities": "^1.0@beta",
         "drupal/masquerade": "^2.0",
         "drupal/preview_link": "^2.1@alpha",
         "drupal/redirect": "^1.10",


### PR DESCRIPTION
Fixes #537

## What does this change?

Adds the [LocalGov Utilities](https://www.drupal.org/project/localgov_utilities) module which includes the localgov_char_count module.

## How to test

Install with this branch with Composer and then enable the localgov_char_count. There's a form for enabling and disabling character counting on title and summary fields at /admin/config/content/localgov-char-count

```
composer require localgovdrupal/localgov:"dev-feature/3.x/537-char-counting as 3.1.2"
drush en localgov_char_count
```
