### PR TITLE
fix: [3.2.x] failing phpunit test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "drupal/admin_toolbar": "^3.0",
-        "drupal/core": "^10.0 || ~11.1.0",
+        "drupal/core": "^10.0 || ~11.0",
         "drupal/gin": "^3.0 || ^4.0",
         "drupal/gin_login": "^2.0.3",
         "drupal/gin_toolbar": "^1.0 || ^2.0",

--- a/tests/src/Functional/LocalGovUpdateTest.php
+++ b/tests/src/Functional/LocalGovUpdateTest.php
@@ -27,6 +27,8 @@ class LocalGovUpdateTest extends UpdatePathTestBase {
     'core.entity_view_display.geo_entity.area.embed',
     'core.entity_view_display.geo_entity.area.full',
     'core.entity_view_display.geo_entity.address.default',
+    'core.entity_view_display.geo_entity.address.embed',
+    'core.entity_view_display.geo_entity.address.full',
     // Missing schema:
     // - content.location.settings.geometry_validation.
     // - content.location.settings.multiple_map.

--- a/tests/src/Functional/LocalGovUpdateTest.php
+++ b/tests/src/Functional/LocalGovUpdateTest.php
@@ -26,6 +26,7 @@ class LocalGovUpdateTest extends UpdatePathTestBase {
     'core.entity_view_display.geo_entity.area.default',
     'core.entity_view_display.geo_entity.area.embed',
     'core.entity_view_display.geo_entity.area.full',
+    'core.entity_view_display.geo_entity.address.default',
     // Missing schema:
     // - content.location.settings.geometry_validation.
     // - content.location.settings.multiple_map.

--- a/tests/src/Functional/LocalGovUpdateTest.php
+++ b/tests/src/Functional/LocalGovUpdateTest.php
@@ -20,15 +20,18 @@ class LocalGovUpdateTest extends UpdatePathTestBase {
     // Missing schema:
     // - 'content.location.settings.reset_map.position'.
     // - 'content.location.settings.weight'.
+    'core.entity_view_display.localgov_geo.address.default',
+    'core.entity_view_display.localgov_geo.address.embed',
+    'core.entity_view_display.localgov_geo.address.full',
     'core.entity_view_display.localgov_geo.area.default',
     'core.entity_view_display.localgov_geo.area.embed',
     'core.entity_view_display.localgov_geo.area.full',
-    'core.entity_view_display.geo_entity.area.default',
-    'core.entity_view_display.geo_entity.area.embed',
-    'core.entity_view_display.geo_entity.area.full',
     'core.entity_view_display.geo_entity.address.default',
     'core.entity_view_display.geo_entity.address.embed',
     'core.entity_view_display.geo_entity.address.full',
+    'core.entity_view_display.geo_entity.area.default',
+    'core.entity_view_display.geo_entity.area.embed',
+    'core.entity_view_display.geo_entity.area.full',
     // Missing schema:
     // - content.location.settings.geometry_validation.
     // - content.location.settings.multiple_map.
@@ -60,6 +63,8 @@ class LocalGovUpdateTest extends UpdatePathTestBase {
     // Incorrect schema:
     // - scheduled_transitions.settings:retain_processed.duration.
     'scheduled_transitions.settings',
+    // Missing schema:
+    'views.view.localgov_directory_channel',
   ];
 
   /**


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #879 the following error on the workflow tests

```
1) Drupal\Tests\localgov\Functional\LocalGovUpdateTest::testUpdate
There should be no errors in configuration 'core.entity_view_display.geo_entity.address.default'. Errors:
Schema key core.entity_view_display.geo_entity.address.default:content.location.settings.leaflet_markercluster.excluded failed with: missing schema

Failed asserting that Array &0 (
    'core.entity_view_display.geo_entity.address.default:content.location.settings.leaflet_markercluster.excluded' => 'missing schema'
) is true.
```

and then following errors, e.g.

```
Failed asserting that Array &0 (
    'core.entity_view_display.localgov_geo.address.default:content.location.settings.leaflet_markercluster.excluded' => 'missing schema'
) is true.

Failed asserting that Array &0 (
    'views.view.localgov_directory_channel:display.embed_map.display_options.style.options.view_mode' => 'missing schema'
) is true.
```