### PR TITLE
Adds editoria11y module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "drupal/gin_login": "^2.0.3",
         "drupal/gin_toolbar": "^1.0 || ^2.0",
         "drupal/entity_browser": "^2.9",
+        "drupal/localgov_editoria11y": "^1.0.0@alpha",
         "drupal/disable_html5_validation": "^2.0",
         "drupal/localgov_utilities": "^1.0@beta",
         "drupal/masquerade": "^2.0",


### PR DESCRIPTION
Closes #859 

## What does this change?

Adds "LocalGov Editoria11y" module, which pulls in the Editoria11y module and configures the permissions for it.

## How to test

1. Install the module
2. Edit content as "LocalGov Editor" role
3. Each page should have the Editoria11y widget in the bottom right corner
4. There should be a general reports page here: https://localgov.ddev.site/admin/reports/editoria11y

## How can we measure success?

More accessible LGD sites!!!

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.