### PR TITLE
Use the appropriate hook 

### DIFF
--- a/localgov.profile
+++ b/localgov.profile
@@ -7,16 +7,18 @@
 
 /**
  * Implements hook_page_attachments_alter().
+ *
+ * Use LocalGov Drupal for site generator metatag.
  */
 function localgov_page_attachments_alter(array &$attachments): void {
   foreach ($attachments['#attached']['html_head'] as &$html_head) {
-    $name = $html_head[1];
-    $core_version = \Drupal::VERSION;
-    $parts = explode('.', $core_version);
+    if ($html_head[1] == 'system_meta_generator') {
+      $parts = explode('.', \Drupal::VERSION);
 
-    if ($name == 'system_meta_generator') {
       $tag = &$html_head[0];
       $tag['#attributes']['content'] = 'Drupal ' . $parts[0] . ' (LocalGov Drupal | https://localgovdrupal.org)';
+
+      break;
     }
   }
 }

--- a/localgov.profile
+++ b/localgov.profile
@@ -6,9 +6,9 @@
  */
 
 /**
- * Implements hook_page_attachments().
+ * Implements hook_page_attachments_alter().
  */
-function localgov_page_attachments(array &$attachments): void {
+function localgov_page_attachments_alter(array &$attachments): void {
   foreach ($attachments['#attached']['html_head'] as &$html_head) {
     $name = $html_head[1];
     $core_version = \Drupal::VERSION;


### PR DESCRIPTION
Ref: #895

## What does this change?

As suggested in #895, uses hook_page_attachments_alter() instead of hook_page_attachments().

## How to test

View source.

## How can we measure success?

Look for the line `<meta name="Generator" content="Drupal 10 (LocalGov Drupal | https://localgovdrupal.org)" />` (and no error message as reported on #895)

## Have we considered potential risks?

Just noting it was originally using the other hook because the Thunder profile did it that way: https://github.com/localgovdrupal/localgov_core/pull/177#issuecomment-1576805488  

## Images
N/A

## Accessibility
N/A