### PR TITLE
fix: include patch to fix breaking tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,9 @@
             "drupal/core": {
                 "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch"
             },
+            "drupal/layout_paragraphs": {
+                "Fix implicit nullable warnings #3502083": "https://www.drupal.org/files/issues/2025-09-23/fix-implicit-nullable-warnings-3502083-7.patch"
+            },
             "drupal/preview_link": {
                 "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",
                 "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-08-15/3449121-10.patch",


### PR DESCRIPTION
## What does this change?

Tests are failing at the moment for php 8.4:
```
There was 1 error:

1) Drupal\Tests\localgov\Functional\LocalGovUpdateTest::testUpdate
Exception: Deprecated function: Drupal\layout_paragraphs\Access\LayoutParagraphsBuilderAccess::access(): Implicitly marking parameter $operation as nullable is deprecated, the explicit nullable type must be used instead
include()() (Line: 576)
```
This includes a patch which should fix that. The change is already in the 2.1.x branch, but there hasn't been a release since it went in.

The patch is at https://www.drupal.org/files/issues/2025-09-23/fix-implicit-nullable-warnings-3502083-7.patch
 
## How to test

Run the tests!

## How can we measure success?

The tests don't break on the exception above.

## Have we considered potential risks?

I don't think there are any.

## Images

N/A

## Accessibility

N/A