### PR TITLE
Include and install entity_reference_unpublished

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "drupal/gin_login": "^2.0.3",
         "drupal/gin_toolbar": "^1.0 || ^2.0",
         "drupal/entity_browser": "^2.9",
+        "drupal/entity_reference_unpublished": "^2.0",
         "drupal/localgov_editoria11y": "^1.0.0@alpha",
         "drupal/disable_html5_validation": "^2.0",
         "drupal/localgov_utilities": "^1.0@beta",

--- a/localgov.info.yml
+++ b/localgov.info.yml
@@ -35,6 +35,7 @@ install:
   - admin_toolbar:admin_toolbar
   - admin_toolbar:admin_toolbar_tools
   - entity_browser:entity_browser
+  - entity_reference_unpublished:entity_reference_unpublished
   - gin_login:gin_login
   - gin_toolbar:gin_toolbar
   - disable_html5_validation:disable_html5_validation


### PR DESCRIPTION
Closes https://github.com/localgovdrupal/localgov/issues/912


Is the profile the best place for this module?

Does it work?

What are risks / side effects

In our case is this true? "Allow referencing unpublished entities if the current user has access to them." from
https://www.drupal.org/project/drupal/issues/2845144 or can people reference entities they can't access?