### PR TITLE
fix: bump geofield_map to supported version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "require-dev": {
         "drupal/core-dev": "^10.0",
-        "drupal/geofield_map": "^3.0"
+        "drupal/geofield_map": "^11.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
This bumps geofield_map dev dependency to a supported version to fix